### PR TITLE
Removed sabnzbdplus-theme-mobile from Dockerfile

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -2,7 +2,6 @@ FROM linuxserver/baseimage
 MAINTAINER Sparklyballs <sparklyballs@linuxserver.io>
 
 ENV APTLIST="sabnzbdplus \
-sabnzbdplus-theme-mobile \
 unrar \
 wget"
 


### PR DESCRIPTION
Fixes https://github.com/linuxserver/docker-sabnzbd/issues/3 where the sabnzbd containers fails to update and start because the sabnzbdplus-theme-mobile has been deprecated.