### PR TITLE
Bump to v1.2.0, added sickbeard_mp4_automator for post-processing

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -24,6 +24,11 @@ RUN \
 	libtbb2 \
 	sabnzbdplus \
 	unrar \
+	ffmpeg \
+	mkvtoolnix \
+	python-pip \
+	python-subliminal \
+	python-guessit \
 	unzip && \
 
 # install build packages
@@ -42,6 +47,10 @@ RUN \
  cd /tmp/par2/par2cmdline-tbb-* && \
  dpkg-buildpackage -b -us -uc && \
  dpkg -i $(readlink -f ../par2-tbb_*.deb) && \
+
+# necessary for mp4_automator
+ pip install qtfaststart && \
+ git clone https://github.com/mdhiggins/sickbeard_mp4_automator.git /mp4_automator && \
 
 # cleanup
  apt-get purge -y --auto-remove \


### PR DESCRIPTION
Hi gang,

This PR adds some dependencies for https://github.com/mdhiggins/sickbeard_mp4_automator, and then clones it to /mp4_automator. It also bumps sabnzbd to v1.2.0 (due to the build process)

There's no immediate functional change, but users are now free create their own post-processing scripts referencing /mp4_automator. 

For ease of use, I on my own installation, I copy the entire /mp4_automator into /config/sickbeard_mp4_automator/, so that I can edit its contents (like the autoProcess.ini file) from an exposed volume. The big deal here is that ffmpeg and all other mp4_automator dependencies are now available to be used.

D

