### PR TITLE
Stops using beta versions of sabnzbdplus in the container

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -17,7 +17,7 @@ ARG BUILD_PACKAGES="\
 
 # install packages
 RUN \
- echo "deb http://ppa.launchpad.net/jcfp/ppa/ubuntu xenial main" | tee -a /etc/apt/sources.list && \
+ echo "deb http://ppa.launchpad.net/jcfp/nobetas/ubuntu xenial main" | tee -a /etc/apt/sources.list && \
  apt-key adv --keyserver hkp://keyserver.ubuntu.com:11371 --recv-keys 0x98703123E0F52B2BE16D586EF13930B14BB9F05F && \
  apt-get update && \
  apt-get install -y \


### PR DESCRIPTION
The `http://ppa.launchpad.net/jcfp/nobetas/ubuntu` source will only have stable versions available.

If beta/rc versions are desired I think they should be in a different tag of the image while `latest` always points to the latest stable release.