### PR TITLE
Add health check for automated system restart

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -40,3 +40,5 @@ COPY root/ /
 # ports and volumes
 EXPOSE 8080 9090
 VOLUME /config /downloads /incomplete-downloads
+
+HEALTHCHECK --interval=200s --timeout=100s CMD curl --fail http://localhost:8080 || exit 1


### PR DESCRIPTION
For users of docker swarm a health check can automatically restart the container due to failure.

<!--- Provide a general summary of your changes in the Title above -->

[linuxserverurl]: https://linuxserver.io
[![linuxserver.io](https://raw.githubusercontent.com/linuxserver/docker-templates/master/linuxserver.io/img/linuxserver_medium.png)][linuxserverurl]
	

<!--- Before submitting a pull request please check the following -->

<!---  That you have made a branch in your fork, we'd rather not merge from your master -->
<!---  That if the PR is addressing an existing issue include, closes #<issue number> , in the body of the PR commit message   -->
<!---  You have included links to any files / patches etc your PR may be using in the body of the PR commit message -->
<!---  -->

##  Thanks, team linuxserver.io

