### PR TITLE
add python3 to image

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -5,7 +5,7 @@ ARG BUILD_DATE
 ARG VERSION
 ARG SABNZBD_VERSION
 LABEL build_version="Linuxserver.io version:- ${VERSION} Build-date:- ${BUILD_DATE}"
-LABEL maintainer="sparklyballs"
+LABEL maintainer="thelamer"
 
 # environment settings
 ARG DEBIAN_FRONTEND="noninteractive"
@@ -34,6 +34,8 @@ RUN \
 	p7zip-full \
 	par2-tbb \
 	python-pip \
+	python3-pip \
+	python3 \
 	${SABNZBD} \
 	unrar \
 	unzip && \
@@ -43,9 +45,16 @@ RUN \
 	pynzb \
 	requests \
 	sabyenc && \
+ pip3 install --no-cache-dir \
+        apprise \
+        chardet \
+        pynzb \
+        requests \
+        sabyenc && \
  echo "**** cleanup ****" && \
  apt-get purge --auto-remove -y \
-	python-pip && \
+	python-pip \
+	python3-pip && \
  apt-get clean && \
  rm -rf \
 	/tmp/* \
@@ -57,4 +66,4 @@ COPY root/ /
 
 # ports and volumes
 EXPOSE 8080 9090
-VOLUME /config /downloads /incomplete-downloads
+VOLUME /config

--- a/Dockerfile.aarch64
+++ b/Dockerfile.aarch64
@@ -5,7 +5,7 @@ ARG BUILD_DATE
 ARG VERSION
 ARG SABNZBD_VERSION
 LABEL build_version="Linuxserver.io version:- ${VERSION} Build-date:- ${BUILD_DATE}"
-LABEL maintainer="sparklyballs"
+LABEL maintainer="thelamer"
 
 # environment settings
 ARG DEBIAN_FRONTEND="noninteractive"
@@ -34,6 +34,8 @@ RUN \
 	p7zip-full \
 	par2-tbb \
 	python-pip \
+	python3-pip \
+	python3 \
 	${SABNZBD} \
 	unrar \
 	unzip && \
@@ -43,9 +45,16 @@ RUN \
 	pynzb \
 	requests \
 	sabyenc && \
+ pip3 install --no-cache-dir \
+        apprise \
+        chardet \
+        pynzb \
+        requests \
+        sabyenc && \
  echo "**** cleanup ****" && \
  apt-get purge --auto-remove -y \
-	python-pip && \
+	python-pip \
+	python3-pip && \
  apt-get clean && \
  rm -rf \
 	/tmp/* \
@@ -57,4 +66,4 @@ COPY root/ /
 
 # ports and volumes
 EXPOSE 8080 9090
-VOLUME /config /downloads /incomplete-downloads
+VOLUME /config

--- a/Dockerfile.armhf
+++ b/Dockerfile.armhf
@@ -5,7 +5,7 @@ ARG BUILD_DATE
 ARG VERSION
 ARG SABNZBD_VERSION
 LABEL build_version="Linuxserver.io version:- ${VERSION} Build-date:- ${BUILD_DATE}"
-LABEL maintainer="sparklyballs"
+LABEL maintainer="thelamer"
 
 # environment settings
 ARG DEBIAN_FRONTEND="noninteractive"
@@ -34,6 +34,8 @@ RUN \
 	p7zip-full \
 	par2-tbb \
 	python-pip \
+	python3-pip \
+	python3 \
 	${SABNZBD} \
 	unrar \
 	unzip && \
@@ -43,9 +45,16 @@ RUN \
 	pynzb \
 	requests \
 	sabyenc && \
+ pip3 install --no-cache-dir \
+        apprise \
+        chardet \
+        pynzb \
+        requests \
+        sabyenc && \
  echo "**** cleanup ****" && \
  apt-get purge --auto-remove -y \
-	python-pip && \
+	python-pip \
+	python3-pip && \
  apt-get clean && \
  rm -rf \
 	/tmp/* \
@@ -57,4 +66,4 @@ COPY root/ /
 
 # ports and volumes
 EXPOSE 8080 9090
-VOLUME /config /downloads /incomplete-downloads
+VOLUME /config

--- a/README.md
+++ b/README.md
@@ -224,6 +224,7 @@ Once registered you can define the dockerfile to use with `-f Dockerfile.aarch64
 
 ## Versions
 
+* **02.01.20:** - Add python3 on top of python2 to image during transition.
 * **23.03.19:** - Switching to new Base images, shift to arm32v7 tag.
 * **25.02.19:** - Rebase to Bionic, add python deps for scripts.
 * **26.01.19:** - Add pipeline logic and multi arch.

--- a/readme-vars.yml
+++ b/readme-vars.yml
@@ -58,6 +58,7 @@ app_setup_block: |
 
 # changelog
 changelogs:
+  - { date: "02.01.20:", desc: "Add python3 on top of python2 to image during transition." }
   - { date: "23.03.19:", desc: "Switching to new Base images, shift to arm32v7 tag." }
   - { date: "25.02.19:", desc: "Rebase to Bionic, add python deps for scripts." }
   - { date: "26.01.19:", desc: "Add pipeline logic and multi arch." }


### PR DESCRIPTION
This just layers python3 on to python2 so people can selectively use the bin with their add-ons as supported while we transition. 

Ref https://github.com/linuxserver/docker-sabnzbd/issues/67