### PR TITLE
Move Unstable to head releases and py3

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -5,7 +5,7 @@ ARG BUILD_DATE
 ARG VERSION
 ARG SABNZBD_VERSION
 LABEL build_version="Linuxserver.io version:- ${VERSION} Build-date:- ${BUILD_DATE}"
-LABEL maintainer="sparklyballs"
+LABEL maintainer="thelamer"
 
 # environment settings
 ARG DEBIAN_FRONTEND="noninteractive"
@@ -19,8 +19,8 @@ RUN \
         gnupg && \
  echo "***** add sabnzbd repositories ****" && \
  apt-key adv --keyserver hkp://keyserver.ubuntu.com:11371 --recv-keys 0x98703123E0F52B2BE16D586EF13930B14BB9F05F && \
- echo "deb http://ppa.launchpad.net/jcfp/ppa/ubuntu bionic main" >> /etc/apt/sources.list.d/sabnzbd.list && \
- echo "deb-src http://ppa.launchpad.net/jcfp/ppa/ubuntu bionic main" >> /etc/apt/sources.list.d/sabnzbd.list && \
+ echo "deb http://ppa.launchpad.net/jcfp/private/ubuntu bionic main" >> /etc/apt/sources.list.d/sabnzbd.list && \
+ echo "deb-src http://ppa.launchpad.net/jcfp/private/ubuntu bionic main" >> /etc/apt/sources.list.d/sabnzbd.list && \
  echo "deb http://ppa.launchpad.net/jcfp/sab-addons/ubuntu bionic main" >> /etc/apt/sources.list.d/sabnzbd.list && \
  echo "deb-src http://ppa.launchpad.net/jcfp/sab-addons/ubuntu bionic main" >> /etc/apt/sources.list.d/sabnzbd.list && \
  echo "**** install packages ****" && \
@@ -34,19 +34,23 @@ RUN \
  apt-get install -y \
 	p7zip-full \
 	par2-tbb \
-	python-pip \
+	python3 \
+	python3-pip \
 	${SABNZBD} \
 	unrar \
 	unzip && \
- pip install --no-cache-dir \
+ pip3 install --no-cache-dir \
 	apprise \
 	chardet \
 	pynzb \
 	requests \
 	sabyenc && \
  echo "**** cleanup ****" && \
+ ln -s \
+	/usr/bin/python3 \
+	/usr/bin/python && \
  apt-get purge --auto-remove -y \
-	python-pip && \
+	python3-pip && \
  apt-get clean && \
  rm -rf \
 	/tmp/* \
@@ -58,4 +62,4 @@ COPY root/ /
 
 # ports and volumes
 EXPOSE 8080 9090
-VOLUME /config /downloads /incomplete-downloads
+VOLUME /config

--- a/Dockerfile.aarch64
+++ b/Dockerfile.aarch64
@@ -5,7 +5,7 @@ ARG BUILD_DATE
 ARG VERSION
 ARG SABNZBD_VERSION
 LABEL build_version="Linuxserver.io version:- ${VERSION} Build-date:- ${BUILD_DATE}"
-LABEL maintainer="sparklyballs"
+LABEL maintainer="thelamer"
 
 # environment settings
 ARG DEBIAN_FRONTEND="noninteractive"
@@ -19,34 +19,38 @@ RUN \
         gnupg && \
  echo "***** add sabnzbd repositories ****" && \
  apt-key adv --keyserver hkp://keyserver.ubuntu.com:11371 --recv-keys 0x98703123E0F52B2BE16D586EF13930B14BB9F05F && \
- echo "deb http://ppa.launchpad.net/jcfp/ppa/ubuntu bionic main" >> /etc/apt/sources.list.d/sabnzbd.list && \
- echo "deb-src http://ppa.launchpad.net/jcfp/ppa/ubuntu bionic main" >> /etc/apt/sources.list.d/sabnzbd.list && \
+ echo "deb http://ppa.launchpad.net/jcfp/private/ubuntu bionic main" >> /etc/apt/sources.list.d/sabnzbd.list && \
+ echo "deb-src http://ppa.launchpad.net/jcfp/private/ubuntu bionic main" >> /etc/apt/sources.list.d/sabnzbd.list && \
  echo "deb http://ppa.launchpad.net/jcfp/sab-addons/ubuntu bionic main" >> /etc/apt/sources.list.d/sabnzbd.list && \
  echo "deb-src http://ppa.launchpad.net/jcfp/sab-addons/ubuntu bionic main" >> /etc/apt/sources.list.d/sabnzbd.list && \
  echo "**** install packages ****" && \
  if [ -z ${SABNZBD_VERSION+x} ]; then \
 	SABNZBD="sabnzbdplus"; \
  else \
-        SABNZBD_CLEAN=$(echo "${SABNZBD_VERSION}"| sed 's/..$//') && \
-        SABNZBD="sabnzbdplus=${SABNZBD_CLEAN}"; \
+	SABNZBD_CLEAN=$(echo "${SABNZBD_VERSION}"| sed 's/..$//') && \
+	SABNZBD="sabnzbdplus=${SABNZBD_CLEAN}"; \
  fi && \
  apt-get update && \
  apt-get install -y \
 	p7zip-full \
 	par2-tbb \
-	python-pip \
+	python3 \
+	python3-pip \
 	${SABNZBD} \
 	unrar \
 	unzip && \
- pip install --no-cache-dir \
+ pip3 install --no-cache-dir \
 	apprise \
 	chardet \
 	pynzb \
 	requests \
 	sabyenc && \
  echo "**** cleanup ****" && \
+ ln -s \
+	/usr/bin/python3 \
+	/usr/bin/python && \
  apt-get purge --auto-remove -y \
-	python-pip && \
+	python3-pip && \
  apt-get clean && \
  rm -rf \
 	/tmp/* \
@@ -58,4 +62,4 @@ COPY root/ /
 
 # ports and volumes
 EXPOSE 8080 9090
-VOLUME /config /downloads /incomplete-downloads
+VOLUME /config

--- a/Dockerfile.armhf
+++ b/Dockerfile.armhf
@@ -5,7 +5,7 @@ ARG BUILD_DATE
 ARG VERSION
 ARG SABNZBD_VERSION
 LABEL build_version="Linuxserver.io version:- ${VERSION} Build-date:- ${BUILD_DATE}"
-LABEL maintainer="sparklyballs"
+LABEL maintainer="thelamer"
 
 # environment settings
 ARG DEBIAN_FRONTEND="noninteractive"
@@ -19,34 +19,38 @@ RUN \
         gnupg && \
  echo "***** add sabnzbd repositories ****" && \
  apt-key adv --keyserver hkp://keyserver.ubuntu.com:11371 --recv-keys 0x98703123E0F52B2BE16D586EF13930B14BB9F05F && \
- echo "deb http://ppa.launchpad.net/jcfp/ppa/ubuntu bionic main" >> /etc/apt/sources.list.d/sabnzbd.list && \
- echo "deb-src http://ppa.launchpad.net/jcfp/ppa/ubuntu bionic main" >> /etc/apt/sources.list.d/sabnzbd.list && \
+ echo "deb http://ppa.launchpad.net/jcfp/private/ubuntu bionic main" >> /etc/apt/sources.list.d/sabnzbd.list && \
+ echo "deb-src http://ppa.launchpad.net/jcfp/private/ubuntu bionic main" >> /etc/apt/sources.list.d/sabnzbd.list && \
  echo "deb http://ppa.launchpad.net/jcfp/sab-addons/ubuntu bionic main" >> /etc/apt/sources.list.d/sabnzbd.list && \
  echo "deb-src http://ppa.launchpad.net/jcfp/sab-addons/ubuntu bionic main" >> /etc/apt/sources.list.d/sabnzbd.list && \
  echo "**** install packages ****" && \
  if [ -z ${SABNZBD_VERSION+x} ]; then \
 	SABNZBD="sabnzbdplus"; \
  else \
-        SABNZBD_CLEAN=$(echo "${SABNZBD_VERSION}"| sed 's/..$//') && \
-        SABNZBD="sabnzbdplus=${SABNZBD_CLEAN}"; \
+	SABNZBD_CLEAN=$(echo "${SABNZBD_VERSION}"| sed 's/..$//') && \
+	SABNZBD="sabnzbdplus=${SABNZBD_CLEAN}"; \
  fi && \
  apt-get update && \
  apt-get install -y \
 	p7zip-full \
 	par2-tbb \
-	python-pip \
+	python3 \
+	python3-pip \
 	${SABNZBD} \
 	unrar \
 	unzip && \
- pip install --no-cache-dir \
+ pip3 install --no-cache-dir \
 	apprise \
 	chardet \
 	pynzb \
 	requests \
 	sabyenc && \
  echo "**** cleanup ****" && \
+ ln -s \
+	/usr/bin/python3 \
+	/usr/bin/python && \
  apt-get purge --auto-remove -y \
-	python-pip && \
+	python3-pip && \
  apt-get clean && \
  rm -rf \
 	/tmp/* \
@@ -58,4 +62,4 @@ COPY root/ /
 
 # ports and volumes
 EXPOSE 8080 9090
-VOLUME /config /downloads /incomplete-downloads
+VOLUME /config

--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -103,7 +103,7 @@ pipeline {
       steps{
         script{
           env.EXT_RELEASE = sh(
-            script: ''' curl -sX GET http://ppa.launchpad.net/jcfp/ppa/ubuntu/dists/bionic/main/binary-amd64/Packages.gz | gunzip |grep -A 7 -m 1 'Package: sabnzbdplus' | awk -F ': ' '/Version/{print $2;exit}' | sed 's/$/-u/' ''',
+            script: ''' curl -sX GET http://ppa.launchpad.net/jcfp/private/ubuntu/dists/bionic/main/binary-amd64/Packages.gz | gunzip |grep -A 7 -m 1 'Package: sabnzbdplus' | awk -F ': ' '/Version/{print $2;exit}' | sed 's/$/-u/' ''',
             returnStdout: true).trim()
             env.RELEASE_LINK = 'custom_command'
         }

--- a/README.md
+++ b/README.md
@@ -224,6 +224,7 @@ Once registered you can define the dockerfile to use with `-f Dockerfile.aarch64
 
 ## Versions
 
+* **03.01.20:** - Use alpha head for unstable with Python3.
 * **23.03.19:** - Switching to new Base images, shift to arm32v7 tag.
 * **25.02.19:** - Rebase to Bionic, add python deps for scripts.
 * **26.01.19:** - Add pipeline logic and multi arch.

--- a/jenkins-vars.yml
+++ b/jenkins-vars.yml
@@ -3,7 +3,7 @@
 # jenkins variables
 project_name: docker-sabnzbd
 external_type: na
-custom_version_command: "curl -sX GET http://ppa.launchpad.net/jcfp/ppa/ubuntu/dists/bionic/main/binary-amd64/Packages.gz | gunzip |grep -A 7 -m 1 'Package: sabnzbdplus' | awk -F ': ' '/Version/{print $2;exit}' | sed 's/$/-u/'"
+custom_version_command: "curl -sX GET http://ppa.launchpad.net/jcfp/private/ubuntu/dists/bionic/main/binary-amd64/Packages.gz | gunzip |grep -A 7 -m 1 'Package: sabnzbdplus' | awk -F ': ' '/Version/{print $2;exit}' | sed 's/$/-u/'"
 release_type: prerelease
 release_tag: unstable
 ls_branch: unstable

--- a/readme-vars.yml
+++ b/readme-vars.yml
@@ -58,6 +58,7 @@ app_setup_block: |
 
 # changelog
 changelogs:
+  - { date: "03.01.20:", desc: "Use alpha head for unstable with Python3." }
   - { date: "23.03.19:", desc: "Switching to new Base images, shift to arm32v7 tag." }
   - { date: "25.02.19:", desc: "Rebase to Bionic, add python deps for scripts." }
   - { date: "26.01.19:", desc: "Add pipeline logic and multi arch." }


### PR DESCRIPTION
This is a big move and might break some people using this tag, but it is labeled unstable and we need to rip the band aid off at some point. 

Would greatly expand the testing pool though for the eventual migration on master to python3. 

I only did a basic loop test , core functionality is there. 