### PR TITLE
FIx commit sha fetch for clashing tags

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -64,7 +64,7 @@ RUN \
   make check && \
   make install && \
   echo "**** Patch Sab commit into version.py ****" && \
-  SAB_COMMIT_SHA=$(curl -s "https://api.github.com/repos/sabnzbd/sabnzbd/git/matching-refs/tags/${SABNZBD_VERSION}" | jq -r '.[].object.sha') && \
+  SAB_COMMIT_SHA=$(curl -s "https://api.github.com/repos/sabnzbd/sabnzbd/git/ref/tags/${SABNZBD_VERSION}" | jq -r '.object.sha') && \
   sed -i "s/__baseline__ .*/__baseline__ = \"${SAB_COMMIT_SHA}\"/" /app/sabnzbd/sabnzbd/version.py && \
   printf "Linuxserver.io version: ${VERSION}\nBuild-date: ${BUILD_DATE}" > /build_version && \
   echo "**** cleanup ****" && \

--- a/Dockerfile.aarch64
+++ b/Dockerfile.aarch64
@@ -64,7 +64,7 @@ RUN \
   make check && \
   make install && \
   echo "**** Patch Sab commit into version.py ****" && \
-  SAB_COMMIT_SHA=$(curl -s "https://api.github.com/repos/sabnzbd/sabnzbd/git/matching-refs/tags/${SABNZBD_VERSION}" | jq -r '.[].object.sha') && \
+  SAB_COMMIT_SHA=$(curl -s "https://api.github.com/repos/sabnzbd/sabnzbd/git/ref/tags/${SABNZBD_VERSION}" | jq -r '.object.sha') && \
   sed -i "s/__baseline__ .*/__baseline__ = \"${SAB_COMMIT_SHA}\"/" /app/sabnzbd/sabnzbd/version.py && \
   printf "Linuxserver.io version: ${VERSION}\nBuild-date: ${BUILD_DATE}" > /build_version && \
   echo "**** cleanup ****" && \

--- a/Dockerfile.riscv64
+++ b/Dockerfile.riscv64
@@ -64,7 +64,7 @@ RUN \
   make check && \
   make install && \
   echo "**** Patch Sab commit into version.py ****" && \
-  SAB_COMMIT_SHA=$(curl -s "https://api.github.com/repos/sabnzbd/sabnzbd/git/matching-refs/tags/${SABNZBD_VERSION}" | jq -r '.[].object.sha') && \
+  SAB_COMMIT_SHA=$(curl -s "https://api.github.com/repos/sabnzbd/sabnzbd/git/ref/tags/${SABNZBD_VERSION}" | jq -r '.object.sha') && \
   sed -i "s/__baseline__ .*/__baseline__ = \"${SAB_COMMIT_SHA}\"/" /app/sabnzbd/sabnzbd/version.py && \
   printf "Linuxserver.io version: ${VERSION}\nBuild-date: ${BUILD_DATE}" > /build_version && \
   echo "**** cleanup ****" && \


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

[linuxserverurl]: https://linuxserver.io
[![linuxserver.io](https://raw.githubusercontent.com/linuxserver/docker-templates/master/linuxserver.io/img/linuxserver_medium.png)][linuxserverurl]


<!--- Before submitting a pull request please check the following -->

<!---  If this is a fix for a typo (in code, documentation, or the README) please file an issue and let us sort it out. We do not need a PR  -->
<!---  Ask yourself if this modification is something the whole userbase will benefit from, if this is a specific change for corner case functionality or plugins please look at making a Docker Mod or local script  https://blog.linuxserver.io/2019/09/14/customizing-our-containers/ -->
<!---  That if the PR is addressing an existing issue include, closes #<issue number> , in the body of the PR commit message   -->
<!---  You have included links to any files / patches etc your PR may be using in the body of the PR commit message -->
<!--- We maintain a changelog of major revisions to the container at the end of readme-vars.yml in the root of this repository, please add your changes there if appropriate -->


<!--- Coding guidelines: -->
<!--- 1. Installed packages in the Dockerfiles should be in alphabetical order -->
<!--- 2. Changes to Dockerfile should be replicated in Dockerfile.armhf and Dockerfile.aarch64 if applicable -->
<!--- 3. Indentation style (tabs vs 4 spaces vs 1 space) should match the rest of the document -->
<!--- 4. Readme is auto generated from readme-vars.yml, make your changes there -->

------------------------------

 - [x] I have read the [contributing](https://github.com/linuxserver/docker-sabnzbd/blob/master/.github/CONTRIBUTING.md) guideline and understand that I have made the correct modifications

------------------------------

<!--- We welcome all PR’s though this doesn’t guarantee it will be accepted. -->

## Description:
matching-refs is a wildcard search but doesn't offer anchors, so e.g. 5.0.2 and 5.0.2RC both match `5.0.2`

As unstable always has "real" tags we can just do a direct tag lookup.

## Benefits of this PR and context:
<!--- Please explain why we should accept this PR. If this fixes an outstanding bug, please reference the issue # -->

## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->


## Source / References:
<!--- Please include any forum posts/github links relevant to the PR -->
