### PR TITLE
Only force the bind address when it is unset or loopback

### DIFF
--- a/readme-vars.yml
+++ b/readme-vars.yml
@@ -83,6 +83,7 @@ init_diagram: |
   "sabnzbd:latest" <- Base Images
 # changelog
 changelogs:
+  - {date: "18.08.26:", desc: "Only force the bind address when it is unset or loopback."}
   - {date: "04.07.26:", desc: "Rebase to Alpine 3.24"}
   - {date: "28.12.25:", desc: "Rebase to Alpine 3.23. Add RISCV build."}
   - {date: "05.07.25:", desc: "Rebase to Alpine 3.22."}

--- a/root/etc/s6-overlay/s6-rc.d/svc-sabnzbd/run
+++ b/root/etc/s6-overlay/s6-rc.d/svc-sabnzbd/run
@@ -3,6 +3,15 @@
 
 FAMILY=::
 
+# Respect a host the user already configured in the [misc] section of
+# sabnzbd.ini, unless it is unset or a loopback address. Passing that same
+# value back through --server is a no-op, so this cannot lock anyone out of
+# the web UI, which is the reason --server is here at all.
+#
+# Section tracking, because the NNTP server entries under [servers] carry
+# their own unindented `host = ...` line.
+CONFIGURED_HOST=$(awk '/^\[/{s=$0} s=="[misc]" && /^host[[:space:]]*=/{sub(/^host[[:space:]]*=[[:space:]]*/,""); print; exit}' /config/sabnzbd.ini 2>/dev/null)
+
 if [[ -z ${LSIO_NON_ROOT_USER} ]]; then
     if ! test -f /proc/net/if_inet6; then
         FAMILY=0.0.0.0
@@ -11,11 +20,21 @@ if [[ -z ${LSIO_NON_ROOT_USER} ]]; then
         rm /etc/hosts.new
     fi
 
+    case ${CONFIGURED_HOST} in
+        "" | 127.0.0.1 | ::1 | localhost) ;;
+        *) FAMILY=${CONFIGURED_HOST} ;;
+    esac
+
     exec \
         s6-notifyoncheck -d -n 300 -w 1000 \
             s6-setuidgid abc python3 /app/sabnzbd/SABnzbd.py \
             --config-file /config --server "$FAMILY"
 else
+    case ${CONFIGURED_HOST} in
+        "" | 127.0.0.1 | ::1 | localhost) ;;
+        *) FAMILY=${CONFIGURED_HOST} ;;
+    esac
+
     exec \
         s6-notifyoncheck -d -n 300 -w 1000 \
             python3 /app/sabnzbd/SABnzbd.py \


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

- [X] I have read the [contributing guideline](https://github.com/linuxserver/docker-sabnzbd/blob/master/.github/CONTRIBUTING.md) and understand that I have made the correct modifications

## Description:

`root/etc/s6-overlay/s6-rc.d/svc-sabnzbd/run` always passes `--server "$FAMILY"` to SABnzbd, which overrides whatever host is stored in `sabnzbd.ini` and is then written straight back into it. This makes that override conditional. Before the `exec`, the script reads the `host` key out of the `[misc]` section of `/config/sabnzbd.ini`. If that value is empty or loopback (`127.0.0.1`, `::1`, `localhost`), `$FAMILY` is imposed exactly as before. If it is anything else, that value is passed back through `--server`, so the flag becomes a no-op and the configured host survives the restart.

The check runs once in each branch rather than once above the `if`, because only the root branch mutates `$FAMILY` for the IPv6 fallback, and that mutation happens after where a shared check would sit. A single check ahead of the `if` would let the fallback clobber a configured host on a machine without IPv6, which is the bug this is meant to fix.

Reading the ini tracks the current section, because the NNTP server entries under `[servers]` carry their own unindented `host = ...` line and matching the wrong one would hand a news server's hostname to `--server`.

## Benefits of this PR and context:

closes #274

This is a narrower version of something raised several times before, most recently in #240, and closed as intended behavior. I am not asking to revisit that decision. Forcing the bind address away from loopback still happens exactly as it does today, for exactly the reason given there, so nobody locks themselves out of the web UI by binding to `127.0.0.1`. This only stops overriding a host that is already something other than unset or loopback, which cannot be the lockout case by definition.

The setup it unblocks is running sabnzbd with `network_mode: container:<other container>`, sharing another container's network namespace, which is the usual way to put a download client behind a VPN container for a kill switch. There is no bridge network to put a reverse proxy on and no port to map in that mode, because the network stack belongs to the other container, so the host has to be set directly and needs to survive a restart.

## How Has This Been Tested?

`shellcheck -s bash` against the modified script, clean, and `bash -n` for syntax. The extraction was checked against four ini shapes: `[misc]` before `[servers]`, `[servers]` before `[misc]`, a loopback value, and no `host` key at all. The reordered case is the one that matters, since a plain `grep '^host'` returns the news server there.

I have not run it inside a built image yet. Happy to do that and report back before merge.

## Source / References:

#240, #116, and the earlier reports of the same behaviour in #2, #35 and #42.
